### PR TITLE
Fix admin-lte directory to be AdminLTE

### DIFF
--- a/blueprints/ember-cli-adminlte/index.js
+++ b/blueprints/ember-cli-adminlte/index.js
@@ -11,7 +11,7 @@ module.exports = {
 
   afterInstall: function(options) {
     return this.addBowerPackagesToProject([
-      {name: 'admin-lte', target: '^2.3.6'}
+      {name: 'AdminLTE', target: 'admin-lte#^2.3.8'}
     ]);
   } // :afterInstall
 


### PR DESCRIPTION
Running  `ember serve` after installing doesn't work, as it relies on
AdminLTE, but bower installs to admin-lte.

Otherwise the paths will need to change to use admin-lte, and this won't
break BC.